### PR TITLE
feat : 회원가입 validation 추가

### DIFF
--- a/src/main/java/com/alt/controller/LoginController.java
+++ b/src/main/java/com/alt/controller/LoginController.java
@@ -111,7 +111,6 @@ public class LoginController {
         log.info("회원가입 권한 성공 : " + clientAuthVO);
 
         clientService.register(clientVO);
-        clientService.Roleregister(clientAuthVO);
 
         return "/client/loginForm";
 

--- a/src/main/java/com/alt/impliment/ClientStore.java
+++ b/src/main/java/com/alt/impliment/ClientStore.java
@@ -1,0 +1,65 @@
+package com.alt.impliment;
+
+import com.alt.domain.ClientAuthVO;
+import com.alt.domain.ClientVO;
+import com.alt.mapper.ClientMapper;
+import java.util.regex.Pattern;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+@Component
+@AllArgsConstructor
+public class ClientStore {
+
+    private final ClientMapper clientMapper;
+
+    public void register(ClientVO clientVO) {
+
+        validationRegister(clientVO);
+
+        clientMapper.register(clientVO);
+
+        ClientAuthVO clientAuthVO = new ClientAuthVO();
+        clientAuthVO.setCid(clientVO.getCid());
+        clientMapper.roleRegister(clientAuthVO);
+    }
+
+    private void validationRegister(ClientVO clientVO) {
+        if (StringUtils.isEmpty(clientVO.getCid())) {
+            throw new IllegalArgumentException();
+        }
+
+        if (clientVO.getCid().length() < 5) {
+            throw new IllegalArgumentException();
+        }
+
+        if (clientVO.getCid().length() > 10) {
+            throw new IllegalArgumentException();
+        }
+
+        Pattern pattern = Pattern.compile("^(01[016789])-(\\d{3,4})-(\\d{4})$");
+
+        if (!pattern.matcher(clientVO.getCphone()).matches()) {
+            throw new IllegalArgumentException();
+        }
+        int phoneNumberLength = clientVO.getCphone().replace("-", "").length();
+
+        if (phoneNumberLength < 10 || phoneNumberLength > 11) {
+            throw new IllegalArgumentException();
+        }
+
+        if (StringUtils.isEmpty(clientVO.getCnick())) {
+            throw new IllegalArgumentException();
+        }
+
+        if (clientVO.getCnick().length() < 2) {
+            throw new IllegalArgumentException();
+        }
+
+        if (clientVO.getCnick().length() > 15) {
+            throw new IllegalArgumentException();
+        }
+    }
+
+}

--- a/src/main/java/com/alt/mapper/ClientMapper.java
+++ b/src/main/java/com/alt/mapper/ClientMapper.java
@@ -21,7 +21,7 @@ public interface ClientMapper {
 
     //
     //client 권한 삽입
-    public void Roleregister(ClientAuthVO clientAuthVO);
+    public void roleRegister(ClientAuthVO clientAuthVO);
 
     //
     //client 체크

--- a/src/main/java/com/alt/service/ClientServiceImpl.java
+++ b/src/main/java/com/alt/service/ClientServiceImpl.java
@@ -1,5 +1,6 @@
 package com.alt.service;
 
+import com.alt.impliment.ClientStore;
 import java.util.HashMap;
 import java.util.List;
 
@@ -25,19 +26,19 @@ public class ClientServiceImpl implements ClientService {
     @Autowired
     private ClientMapper clientMapper;
 
+    @Autowired
+    private ClientStore clientStore;
+
     //회원 추가
     public String register(ClientVO clientVO) {
-        log.info("회원 추가 Service " + clientVO);
-        clientMapper.register(clientVO);
-
+        clientStore.register(clientVO);
         return "register";
-
     }
 
     //권한 추가
     public String Roleregister(ClientAuthVO clientAuthVO) {
         log.info("회원 추가 Service " + clientAuthVO);
-        clientMapper.Roleregister(clientAuthVO);
+        clientMapper.roleRegister(clientAuthVO);
 
         return "Roleregister";
 

--- a/src/main/resources/com/alt/mapper/ClientMapper.xml
+++ b/src/main/resources/com/alt/mapper/ClientMapper.xml
@@ -27,7 +27,7 @@
 	</insert>    
 	
 	<!-- 아이디 삽입 -->
-	<insert id="Roleregister" parameterType="com.alt.domain.ClientAuthVO">
+	<insert id="roleRegister" parameterType="com.alt.domain.ClientAuthVO">
 		insert into alt.clientauth 
 		values (#{cid}, 'ROLE_CLIENT') 
 	</insert>  

--- a/src/test/java/com/alt/controller/LoginControllerTest.java
+++ b/src/test/java/com/alt/controller/LoginControllerTest.java
@@ -1,0 +1,113 @@
+package com.alt.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.alt.domain.ClientVO;
+import com.alt.domain.MemberVO;
+import com.alt.mapper.ClientMapper;
+import com.alt.service.ClientServiceImpl;
+import javax.servlet.ServletException;
+import lombok.Setter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.mock.web.MockServletConfig;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.servlet.DispatcherServlet;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(locations = {
+    "file:src/main/webapp/WEB-INF/spring/root-context.xml",
+    "file:src/main/webapp/WEB-INF/spring/security-context.xml",
+    "file:src/main/webapp/WEB-INF/spring/appServlet/servlet-context.xml"
+})
+@WebAppConfiguration
+@Transactional
+public class LoginControllerTest {
+
+    @Autowired
+    private WebApplicationContext webApplicationContext;
+
+    @Setter(onMethod_ = @Autowired)
+    private ClientMapper clientMapper;
+
+    @Setter(onMethod_ = @Autowired)
+    private ClientServiceImpl clientService;
+
+    private DispatcherServlet dispatcherServlet;
+    private MockHttpServletRequest request;
+    private MockHttpServletResponse response;
+
+    private ClientVO newClient;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        this.request = new MockHttpServletRequest();
+        this.response = new MockHttpServletResponse();
+        this.dispatcherServlet = new DispatcherServlet(webApplicationContext);
+        this.dispatcherServlet.init(new MockServletConfig());
+    }
+
+    @BeforeEach
+    public void createNewUser() throws Exception {
+        newClient = new ClientVO();
+        this.newClient.setCid("testId");
+        this.newClient.setCpassword("testPassword");
+        this.newClient.setCname("testName");
+        this.newClient.setCnick("testNickName");
+        this.newClient.setCphone("010-1234-1234");
+        this.newClient.setCaddress("서울시 강남구");
+    }
+
+    @Test
+    @DisplayName("신규 사용자가 회원가입을 하면 회원가입이 완료된다")
+    public void whenJoinNewClientThenSuccess() throws Exception {
+
+        //given
+        request.setMethod("POST");
+        request.setRequestURI("/client_join");
+
+        request.setParameter("cid", newClient.getCid());
+        request.setParameter("cnick", newClient.getCnick());
+        request.setParameter("cpassword", newClient.getCpassword());
+        request.setParameter("cname", newClient.getCname());
+        request.setParameter("cphone", newClient.getCphone());
+        request.setParameter("caddress", newClient.getCaddress());
+
+        //when
+        dispatcherServlet.service(request, response);
+
+        //then
+        assertEquals(HttpStatus.OK.value(), response.getStatus());
+        assertEquals("", response.getContentAsString()); // 기대하는 응답 내용 검증
+
+        ClientVO joinedClient = clientService.listClient(newClient.getCid());
+        assertEquals(newClient.getCid(), joinedClient.getCid());
+        assertEquals(newClient.getCpassword(), joinedClient.getCpassword());
+        assertEquals(newClient.getCname(), joinedClient.getCname());
+        assertEquals(newClient.getCnick(), joinedClient.getCnick());
+        assertEquals(newClient.getCphone(), joinedClient.getCphone());
+        assertEquals(newClient.getCaddress(), joinedClient.getCaddress());
+        assertEquals(0, joinedClient.getCreport());
+        assertEquals("N", joinedClient.getCdelete());
+        assertEquals("?", joinedClient.getCgrade());
+        assertEquals("0", joinedClient.getEnable());
+
+        // 현재는 auth를 가져오는 service가 없어 임시로 mapper 사용
+        MemberVO testId = clientMapper.read("testId");
+        assertEquals(1, testId.getClientAuthList().size());
+        assertEquals("ROLE_CLIENT", testId.getClientAuthList().get(0).getAuthority());
+
+    }
+
+}

--- a/src/test/java/com/alt/service/ClientServiceImplTest.java
+++ b/src/test/java/com/alt/service/ClientServiceImplTest.java
@@ -1,12 +1,22 @@
 package com.alt.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import com.alt.domain.ClientAuthVO;
 import com.alt.domain.ClientVO;
+import com.alt.domain.MemberVO;
+import com.alt.mapper.ClientMapper;
+import java.util.stream.Stream;
 import lombok.Setter;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
@@ -24,13 +34,15 @@ import org.springframework.transaction.annotation.Transactional;
 public class ClientServiceImplTest {
 
     @Setter(onMethod_ = @Autowired)
+    private ClientMapper clientMapper;
+
+    @Setter(onMethod_ = @Autowired)
     private ClientServiceImpl clientService;
 
-    @Test
-    public void testRegister() {
+    private ClientVO newClient;
 
-        //given
-        ClientVO newClient;
+    @BeforeEach
+    public void createNewClient() throws Exception {
         newClient = new ClientVO();
         newClient.setCid("testId");
         newClient.setCpassword("testPassword");
@@ -38,11 +50,108 @@ public class ClientServiceImplTest {
         newClient.setCnick("testNickName");
         newClient.setCphone("010-1234-1234");
         newClient.setCaddress("서울시 강남구");
+    }
+
+    @Test
+    @DisplayName("신규 사용자가 회원가입을 하면 회원가입이 완료된다")
+    public void whenJoinNewClientThenSuccess() {
+
+        //given
+        ClientVO newClient = this.newClient;
+
+        ClientAuthVO newClientAuth = new ClientAuthVO();
+        newClientAuth.setCid("testId");
+        newClientAuth.setAuthority("ROLE_CLIENT");
 
         //when
-        String register = clientService.register(newClient);
+        String registeredResult = clientService.register(newClient);
 
+        //then
+        ClientVO joinedClient = clientService.listClient("testId");
+        assertEquals("register", registeredResult);
+        assertEquals(newClient.getCid(), joinedClient.getCid());
+        assertEquals(newClient.getCpassword(), joinedClient.getCpassword());
+        assertEquals(newClient.getCname(), joinedClient.getCname());
+        assertEquals(newClient.getCnick(), joinedClient.getCnick());
+        assertEquals(newClient.getCphone(), joinedClient.getCphone());
+        assertEquals(newClient.getCaddress(), joinedClient.getCaddress());
+        assertEquals(0, joinedClient.getCreport());
+        assertEquals("N", joinedClient.getCdelete());
+        assertEquals("?", joinedClient.getCgrade());
+        assertEquals("0", joinedClient.getEnable());
 
+        // 현재는 auth를 가져오는 service가 없어 임시로 mapper 사용
+        MemberVO testId = clientMapper.read("testId");
+        assertEquals(1, testId.getClientAuthList().size());
+        assertEquals("ROLE_CLIENT", testId.getClientAuthList().get(0).getAuthority());
+    }
 
+    @ParameterizedTest(name = "[{index}] {0}")
+    @DisplayName("회원 가입 시 ID format이 다르면 에러가 발생한다.")
+    @MethodSource("provideInvalidIdForJoin")
+    public void whenInputInvalidFormatIdThenException(String message, String id) {
+        //given
+        ClientVO invalidIdClient = newClient;
+        invalidIdClient.setCid(id);
+
+        //when
+        //then
+        assertThrows(IllegalArgumentException.class, () ->
+            clientService.register(invalidIdClient)
+        );
+    }
+    @ParameterizedTest(name = "[{index}] {0}")
+    @DisplayName("회원 가입 시 핸드폰 번호 format이 다르면 에러가 발생한다.")
+    @MethodSource("provideInvalidPhoneNumberForJoin")
+    public void whenInputInvalidFormatPhoneNumberThenException(String message, String phoneNumber) {
+        //given
+        ClientVO invalidPhoneClient = newClient;
+        invalidPhoneClient.setCphone(phoneNumber);
+
+        //when
+        //then
+        assertThrows(IllegalArgumentException.class, () ->
+            clientService.register(invalidPhoneClient)
+        );
+    }
+
+    @ParameterizedTest(name = "[{index}] {0}")
+    @DisplayName("회원 가입 시 닉네암 format이 다르면 에러가 발생한다.")
+    @MethodSource("provideInvalidNicknameForJoin")
+    public void whenInputInvalidFormatNicknameThenException(String message, String nickname) {
+
+        //given
+        ClientVO invalidNicknameClient = newClient;
+        invalidNicknameClient.setCnick(nickname);
+
+        //when
+        //then
+        assertThrows(IllegalArgumentException.class, () ->
+            clientService.register(invalidNicknameClient)
+        );
+
+    }
+
+    public static Stream<Arguments> provideInvalidIdForJoin() {
+        return Stream.of(
+            Arguments.of("빈 값의 ID", ""),
+            Arguments.of("4자리 이하의 ID", "1234"),
+            Arguments.of("31자리 이상의 ID", "1234567890123456789012345678901")
+        );
+    }
+    public static Stream<Arguments> provideInvalidPhoneNumberForJoin() {
+        return Stream.of(
+            Arguments.of("빈 값의 핸드폰 번호", ""),
+            Arguments.of("'-'제외 하고 10~11자리가 아닌 핸드폰 번호", "123456789"),
+            Arguments.of("'-'가 없는 핸드폰 번호", "01012341234")
+        );
+    }
+
+    private static Stream<Arguments> provideInvalidNicknameForJoin() {
+        return Stream.of(
+            Arguments.of("빈 값의 닉네임", ""),
+            Arguments.of("1자리 이하의 닉네임", "1"),
+            Arguments.of("16자리 이상의 닉네임", "1234567890123456")
+        );
     }
 }


### PR DESCRIPTION
## Why
회원 가입 시에 validation이 없어 client가 데이터를 조작하여 보내면 server에 그대로 저장될 가능성이 있음.

## What
- 회원 가입 시에 ID, 닉네임, 핸드폰 번호 validation 추가.
- service, impliment 구조로 변경하여 service의 추상화를 높이고 impliment로 세부 구현 사항을 만들어 재사용성을 높임.
- 통합 테스트를 작성하여 기존의 서비스가 문제 없는지 확인.

## Test
- controller
  - whenJoinNewClientThenSuccess()
    - 신규 사용자가 회원가입을 하면 회원가입이 완료된다
- service
  - whenJoinNewClientThenSuccess()
    - 신규 사용자가 회원가입을 하면 회원가입이 완료된다
  - whenInputInvalidFormatIdThenException()
    - 회원 가입 시 ID format이 다르면 에러가 발생한다.
      - 빈 값의 ID
      - 4자리 이하의 ID
      - 31자리 이상의 ID
  - whenInputInvalidFormatPhoneNumberThenException()
    - 회원 가입 시 ID format이 다르면 에러가 발생한다.
      - 빈 값의 핸드폰 번호
      - '-'제외 하고 10~11자리가 아닌 핸드폰 번호
      - '-'가 없는 핸드폰 번호
  - whenInputInvalidFormatNicknameThenException()
    - 회원 가입 시 ID format이 다르면 에러가 발생한다.
      - 빈 값의 닉네임
      - 1자리 이하의 닉네임
      - 16자리 이상의 닉네임

## Other
- 없음