### PR TITLE
test : loginController 테스트 작성

### DIFF
--- a/src/test/java/com/alt/controller/LoginControllerTest.java
+++ b/src/test/java/com/alt/controller/LoginControllerTest.java
@@ -5,8 +5,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.alt.domain.ClientVO;
 import com.alt.domain.MemberVO;
+import com.alt.domain.VendorAuthVO;
+import com.alt.domain.VendorVO;
 import com.alt.mapper.ClientMapper;
+import com.alt.mapper.VendorMapper;
 import com.alt.service.ClientServiceImpl;
+import com.alt.service.VendorServiceImpl;
 import javax.servlet.ServletException;
 import lombok.Setter;
 import org.junit.jupiter.api.BeforeEach;
@@ -44,11 +48,20 @@ public class LoginControllerTest {
     @Setter(onMethod_ = @Autowired)
     private ClientServiceImpl clientService;
 
+    @Setter(onMethod_ = @Autowired)
+    private VendorServiceImpl vendorService;
+
+    @Setter(onMethod_ = @Autowired)
+    private VendorMapper vendorMapper;
+
     private DispatcherServlet dispatcherServlet;
     private MockHttpServletRequest request;
     private MockHttpServletResponse response;
 
     private ClientVO newClient;
+    private VendorVO newVendor;
+    private ClientVO alreadyJoinedClient;
+    private VendorVO alreadyJoinedVendor;
 
     @BeforeEach
     public void setUp() throws Exception {
@@ -67,7 +80,45 @@ public class LoginControllerTest {
         this.newClient.setCnick("testNickName");
         this.newClient.setCphone("010-1234-1234");
         this.newClient.setCaddress("서울시 강남구");
+
+        newVendor = new VendorVO();
+        this.newVendor.setVid("testVendorId");
+        this.newVendor.setVpassword("testPassword");
+        this.newVendor.setVname("가게 상호");
+        this.newVendor.setVregisterNo("123-12-123456");
+        this.newVendor.setVphone("010-1234-1234");
+        this.newVendor.setVaddress("서울시 강남구");
+        this.newVendor.setVinfo("가게 설명");
     }
+
+    @BeforeEach
+    public void alreadyJoinedUser() throws Exception {
+        alreadyJoinedClient = new ClientVO();
+        this.alreadyJoinedClient.setCid("testId11");
+        this.alreadyJoinedClient.setCpassword("testPassword");
+        this.alreadyJoinedClient.setCname("duplicateName");
+        this.alreadyJoinedClient.setCnick("nicknamedupli");
+        this.alreadyJoinedClient.setCphone("010-9999-9999");
+        this.alreadyJoinedClient.setCaddress("서울시 강남구");
+
+        alreadyJoinedVendor = new VendorVO();
+        this.alreadyJoinedVendor.setVid("duplicateVendorId");
+        this.alreadyJoinedVendor.setVpassword("duplicatePassword");
+        this.alreadyJoinedVendor.setVname("duplicate 가게 상호");
+        this.alreadyJoinedVendor.setVregisterNo("999-99-999999");
+        this.alreadyJoinedVendor.setVphone("010-9999-9999");
+        this.alreadyJoinedVendor.setVaddress("서울시 강남구");
+        this.alreadyJoinedVendor.setVinfo("가게 설명");
+
+        clientService.register(alreadyJoinedClient);
+
+        vendorService.VendorRegister(alreadyJoinedVendor);
+        VendorAuthVO vendorAuthVO = new VendorAuthVO();
+        vendorAuthVO.setVid(alreadyJoinedVendor.getVid());
+        vendorAuthVO.setAuthority("ROLE_VENDOR");
+        vendorService.RoleRegister(vendorAuthVO);
+    }
+
 
     @Test
     @DisplayName("신규 사용자가 회원가입을 하면 회원가입이 완료된다")
@@ -110,4 +161,297 @@ public class LoginControllerTest {
 
     }
 
+    @Test
+    @DisplayName("일반 회원의 아이디 검사 시 중복된 ID가 없다면 'usable' 를 리턴한다.")
+    public void whenNonDuplicateClientUserIdCheckThenSuccess() throws Exception {
+
+        //given
+        request.setMethod("GET");
+        request.setRequestURI("/idCheck");
+
+        request.setParameter("id", newClient.getCid());
+
+        //when
+        dispatcherServlet.service(request, response);
+
+        //then
+        assertEquals(HttpStatus.OK.value(), response.getStatus());
+        assertEquals("usable", response.getContentAsString()); // 기대하는 응답 내용 검증
+    }
+
+    @Test
+    @DisplayName("일반 회원의 아이디 검사 시 중복된 ID가 있다면 'not_usable' 를 리턴한다.")
+    public void whenDuplicateClientUserIdCheckThenSuccess() throws Exception {
+
+        //given
+        request.setMethod("GET");
+        request.setRequestURI("/idCheck");
+
+        request.setParameter("id", alreadyJoinedClient.getCid());
+
+        //when
+        dispatcherServlet.service(request, response);
+
+        //then
+        assertEquals(HttpStatus.OK.value(), response.getStatus());
+        assertEquals("not_usable", response.getContentAsString()); // 기대하는 응답 내용 검증
+    }
+
+    @Test
+    @DisplayName("일반 회원의 닉네임 검사 시 중복된 닉네임이 없다면 'usable' 를 리턴한다.")
+    public void whenNonDuplicateClientUserNicknameCheckThenSuccess() throws Exception {
+
+        //given
+        request.setMethod("GET");
+        request.setRequestURI("/nickCheck");
+
+        request.setParameter("nick", newClient.getCnick());
+
+        //when
+        dispatcherServlet.service(request, response);
+
+        //then
+        assertEquals(HttpStatus.OK.value(), response.getStatus());
+        assertEquals("usable", response.getContentAsString()); // 기대하는 응답 내용 검증
+    }
+
+    @Test
+    @DisplayName("일반 회원의 닉네임 검사 시 중복된 닉네임이 있다면 'not_usable' 를 리턴한다.")
+    public void whenDuplicateClientUserNicknameCheckThenSuccess() throws Exception {
+
+        //given
+        request.setMethod("GET");
+        request.setRequestURI("/nickCheck");
+
+        request.setParameter("nick", alreadyJoinedClient.getCnick());
+
+        //when
+        dispatcherServlet.service(request, response);
+
+        //then
+        assertEquals(HttpStatus.OK.value(), response.getStatus());
+        assertEquals("not_usable", response.getContentAsString()); // 기대하는 응답 내용 검증
+    }
+
+    @Test
+    @DisplayName("일반 회원의 핸드폰 번호 검사 시 중복된 핸드폰 번호가 없다면 'usable' 를 리턴한다.")
+    public void whenNonDuplicateClientUserPhoneCheckThenSuccess() throws Exception {
+
+        //given
+        request.setMethod("GET");
+        request.setRequestURI("/phoneCheck_client");
+
+        request.setParameter("cphone", newClient.getCphone());
+
+        //when
+        dispatcherServlet.service(request, response);
+
+        //then
+        assertEquals(HttpStatus.OK.value(), response.getStatus());
+        assertEquals("usable", response.getContentAsString()); // 기대하는 응답 내용 검증
+    }
+
+    @Test
+    @DisplayName("일반 회원의 핸드폰 번호 검사 시 중복된 핸드폰 번호가 있다면 'not_usable' 를 리턴한다.")
+    public void whenDuplicateClientUserPhoneCheckThenSuccess() throws Exception {
+
+        //given
+        request.setMethod("GET");
+        request.setRequestURI("/phoneCheck_client");
+
+        request.setParameter("cphone", alreadyJoinedClient.getCphone());
+
+        //when
+        dispatcherServlet.service(request, response);
+
+        //then
+        assertEquals(HttpStatus.OK.value(), response.getStatus());
+        assertEquals("not_usable", response.getContentAsString()); // 기대하는 응답 내용 검증
+    }
+
+    @Test
+    @DisplayName("신규 판매자가 회원가입을 하면 회원가입이 완료된다")
+    public void whenJoinNewVendorThenSuccess() throws Exception {
+
+        //given
+        request.setMethod("POST");
+        request.setRequestURI("/vendor_join");
+
+        request.setParameter("vid", newVendor.getVid());
+        request.setParameter("vpassword", newVendor.getVpassword());
+        request.setParameter("vname", newVendor.getVname());
+        request.setParameter("vregisterNo", newVendor.getVregisterNo());
+        request.setParameter("vphone", newVendor.getVphone());
+        request.setParameter("vaddress", newVendor.getVaddress());
+        request.setParameter("vinfo", newVendor.getVinfo());
+
+        //when
+        dispatcherServlet.service(request, response);
+
+        //then
+        assertEquals(HttpStatus.OK.value(), response.getStatus());
+        assertEquals("", response.getContentAsString()); // 기대하는 응답 내용 검증
+
+        VendorVO joinedVendor = vendorService.listVendor(newVendor.getVid());
+        assertEquals(newVendor.getVid(), joinedVendor.getVid());
+        assertEquals(newVendor.getVpassword(), joinedVendor.getVpassword());
+        assertEquals(newVendor.getVname(), joinedVendor.getVname());
+        assertEquals(newVendor.getVregisterNo(), joinedVendor.getVregisterNo());
+        assertEquals(newVendor.getVphone(), joinedVendor.getVphone());
+        assertEquals(newVendor.getVaddress(), joinedVendor.getVaddress());
+        assertEquals(0, joinedVendor.getVreport());
+        assertEquals("N", joinedVendor.getVdelete());
+        assertEquals("?", joinedVendor.getVgrade());
+        assertEquals(0, joinedVendor.getEnable());
+
+        // 현재는 auth를 가져오는 service가 없어 임시로 mapper 사용
+        MemberVO testId = vendorMapper.read(newVendor.getVid());
+        assertEquals(1, testId.getVendorAuthList().size());
+        assertEquals("ROLE_VENDOR", testId.getVendorAuthList().get(0).getAuthority());
+
+    }
+
+    @Test
+    @DisplayName("판매자의 ID 검사 시 중복된 ID가 없다면 'usable' 를 리턴한다.")
+    public void whenNonDuplicateVendorIdCheckThenSuccess() throws Exception {
+
+        //given
+        request.setMethod("GET");
+        request.setRequestURI("/vendoridCheck");
+
+        request.setParameter("vid", newVendor.getVid());
+
+        //when
+        dispatcherServlet.service(request, response);
+
+        //then
+        assertEquals(HttpStatus.OK.value(), response.getStatus());
+        assertEquals("usable", response.getContentAsString()); // 기대하는 응답 내용 검증
+    }
+
+    @Test
+    @DisplayName("판매자의 ID 검사 시 중복된 ID가 있다면 'not_usable' 를 리턴한다.")
+    public void whenDuplicateVendorIdCheckThenSuccess() throws Exception {
+
+        //given
+        request.setMethod("GET");
+        request.setRequestURI("/vendoridCheck");
+
+        request.setParameter("vid", alreadyJoinedVendor.getVid());
+
+        //when
+        dispatcherServlet.service(request, response);
+
+        //then
+        assertEquals(HttpStatus.OK.value(), response.getStatus());
+        assertEquals("not_usable", response.getContentAsString()); // 기대하는 응답 내용 검증
+    }
+
+    @Test
+    @DisplayName("판매자의 상호 검사 시 중복된 상호가 없다면 'usable' 를 리턴한다.")
+    public void whenNonDuplicateVendorNameCheckThenSuccess() throws Exception {
+
+        //given
+        request.setMethod("GET");
+        request.setRequestURI("/vendorName");
+
+        request.setParameter("vname", newVendor.getVname());
+
+        //when
+        dispatcherServlet.service(request, response);
+
+        //then
+        assertEquals(HttpStatus.OK.value(), response.getStatus());
+        assertEquals("usable", response.getContentAsString()); // 기대하는 응답 내용 검증
+    }
+
+    @Test
+    @DisplayName("판매자의 상호 검사 시 중복된 상호가 있다면 'not_usable' 를 리턴한다.")
+    public void whenDuplicateVendorNameCheckThenSuccess() throws Exception {
+
+        //given
+        request.setMethod("GET");
+        request.setRequestURI("/vendorName");
+
+        request.setParameter("vname", alreadyJoinedVendor.getVname());
+
+        //when
+        dispatcherServlet.service(request, response);
+
+        //then
+        assertEquals(HttpStatus.OK.value(), response.getStatus());
+        assertEquals("not_usable", response.getContentAsString()); // 기대하는 응답 내용 검증
+    }
+
+    @Test
+    @DisplayName("판매자의 사업자번호 검사 시 중복된 사업자번호가 없다면 'usable' 를 리턴한다.")
+    public void whenNonDuplicateVendorRegisterNoCheckThenSuccess() throws Exception {
+
+        //given
+        request.setMethod("GET");
+        request.setRequestURI("/vendorNoCheck");
+
+        request.setParameter("vregisterNo", newVendor.getVregisterNo());
+
+        //when
+        dispatcherServlet.service(request, response);
+
+        //then
+        assertEquals(HttpStatus.OK.value(), response.getStatus());
+        assertEquals("usable", response.getContentAsString()); // 기대하는 응답 내용 검증
+    }
+
+    @Test
+    @DisplayName("판매자의 사업자번호 검사 시 중복된 사업자번호가 있다면 'not_usable' 를 리턴한다.")
+    public void whenDuplicateVendorRegisterNoCheckThenSuccess() throws Exception {
+
+        //given
+        request.setMethod("GET");
+        request.setRequestURI("/vendorNoCheck");
+
+        request.setParameter("vregisterNo", alreadyJoinedVendor.getVregisterNo());
+
+        //when
+        dispatcherServlet.service(request, response);
+
+        //then
+        assertEquals(HttpStatus.OK.value(), response.getStatus());
+        assertEquals("not_usable", response.getContentAsString()); // 기대하는 응답 내용 검증
+    }
+
+    @Test
+    @DisplayName("판매자의 핸드폰 번호 검사 시 중복된 핸드폰 번호가 없다면 'usable' 를 리턴한다.")
+    public void whenNonDuplicateVendorPhoneNumberCheckThenSuccess() throws Exception {
+
+        //given
+        request.setMethod("GET");
+        request.setRequestURI("/phoneCheck_vendor");
+
+        request.setParameter("vphone", newVendor.getVphone());
+
+        //when
+        dispatcherServlet.service(request, response);
+
+        //then
+        assertEquals(HttpStatus.OK.value(), response.getStatus());
+        assertEquals("usable", response.getContentAsString()); // 기대하는 응답 내용 검증
+    }
+
+    @Test
+    @DisplayName("판매자의 핸드폰 번호 검사 시 중복된 핸드폰 번호가 있다면 'not_usable' 를 리턴한다.")
+    public void whenDuplicateVendorPhoneNumberCheckThenSuccess() throws Exception {
+
+        //given
+        request.setMethod("GET");
+        request.setRequestURI("/phoneCheck_vendor");
+
+        request.setParameter("vphone", alreadyJoinedVendor.getVphone());
+
+        //when
+        dispatcherServlet.service(request, response);
+
+        //then
+        assertEquals(HttpStatus.OK.value(), response.getStatus());
+        assertEquals("not_usable", response.getContentAsString()); // 기대하는 응답 내용 검증
+    }
 }


### PR DESCRIPTION
## Why
login controller 테스트 작성

## What
- 중복 체크 테스트 작성
- 사업자 회원 가입 테스트 작성
- login controller 에 대한 대부분의 테스트를 작성
- 페이지를 불러오는 end point는 일부 작성

## Test
- controller
  - 회원 중복 검사
    - whenNonDuplicateClientUserIdCheckThenSuccess
      - 일반 회원의 아이디 검사 시 중복된 ID가 없다면 'usable' 를 리턴한다.
    - whenDuplicateClientUserIdCheckThenSuccess
      - 일반 회원의 아이디 검사 시 중복된 ID가 있다면 'not_usable' 를 리턴한다.
    - whenNonDuplicateClientUserNicknameCheckThenSuccess
      - 일반 회원의 닉네임 검사 시 중복된 닉네임이 없다면 'usable' 를 리턴한다.
    - whenDuplicateClientUserNicknameCheckThenSuccess
      - 일반 회원의 닉네임 검사 시 중복된 닉네임이 있다면 'not_usable' 를 리턴한다..
    - whenNonDuplicateClientUserPhoneCheckThenSuccess
      - 일반 회원의 핸드폰 번호 검사 시 중복된 핸드폰 번호가 없다면 'usable' 를 리턴한다.
    - whenDuplicateClientUserPhoneCheckThenSuccess
      - 일반 회원의 핸드폰 번호 검사 시 중복된 핸드폰 번호가 있다면 'not_usable' 를 리턴한다.
  - 판매자 회원 가입
    - whenJoinNewVendorThenSuccess
      - 신규 판매자가 회원가입을 하면 회원가입이 완료된다
  - 판매자 중복 검사
    - whenNonDuplicateVendorIdCheckThenSuccess
      - 판매자의 ID 검사 시 중복된 ID가 없다면 'usable' 를 리턴한다.
    - whenDuplicateVendorIdCheckThenSuccess
      - 판매자의 ID 검사 시 중복된 ID가 있다면 'not_usable' 를 리턴한다.
    - whenNonDuplicateVendorNameCheckThenSuccess
      - 판매자의 상호 검사 시 중복된 상호가 없다면 'usable' 를 리턴한다.
    - whenDuplicateVendorNameCheckThenSuccess
      - 판매자의 상호 검사 시 중복된 상호가 있다면 'not_usable' 를 리턴한다.
    - whenNonDuplicateVendorRegisterNoCheckThenSuccess
      - 판매자의 사업자번호 검사 시 중복된 사업자번호가 없다면 'usable' 를 리턴한다.
    - whenDuplicateVendorRegisterNoCheckThenSuccess
      - 판매자의 사업자번호 검사 시 중복된 사업자번호가 있다면 'not_usable' 를 리턴한다.
    - whenNonDuplicateVendorPhoneNumberCheckThenSuccess
      - 판매자의 핸드폰 번호 검사 시 중복된 핸드폰 번호가 없다면 'usable' 를 리턴한다.
    - whenDuplicateVendorPhoneNumberCheckThenSuccess
      - 판매자의 핸드폰 번호 검사 시 중복된 핸드폰 번호가 있다면 'not_usable' 를 리턴한다.
## Other
- 현재 행복 경로 테스트만 작성이 되어있어 다른 케이스도 테스트 작성 필요