### PR TITLE
fix : 판매 게시글 수정 테스트의 url이 등록으로 되어있는 오류 수정

### DIFF
--- a/src/test/java/com/alt/controller/BoardControllerTest.java
+++ b/src/test/java/com/alt/controller/BoardControllerTest.java
@@ -557,7 +557,8 @@ public class BoardControllerTest {
         modifySaleBoardVO.getAttachList().get(0).setSuuid(UUID.randomUUID().toString());
         modifySaleBoardVO.getAttachList().get(1).setSuuid(UUID.randomUUID().toString());
 
-        MvcResult result = mockMvc.perform(post("/board/saleRegister")
+        MvcResult result = mockMvc.perform(post("/board/saleModify")
+                .param("sno", String.valueOf(modifySaleBoardVO.getSno()))
                 .param("vid", modifySaleBoardVO.getVid())
                 .param("pcode", String.valueOf(modifySaleBoardVO.getPcode()))
                 .param("stitle", modifySaleBoardVO.getStitle())
@@ -579,10 +580,7 @@ public class BoardControllerTest {
             .andExpect(flash().attributeExists("result"))
             .andReturn();
 
-        //FlashMap 값 확인
-        Map<String, ?> flashMap = result.getFlashMap();
-
-        Integer registerSno = (Integer) flashMap.get("result");
+        int registerSno = modifySaleBoardVO.getSno();
 
         MvcResult mvcResult = mockMvc.perform(get("/board/saleDetail")
                 .contentType(MediaType.APPLICATION_JSON)


### PR DESCRIPTION
## Why
whenModifySaleProductThenSuccess 테스트의 url이 /board/saleRegister 로 되어있어 /board/saleModify 테스트가 진행 되지 않음

## What
-  /board/saleRegister 에서 /board/saleModify 로 수정
- 값 검증 시 model에 담겨 있는 값이 아닌 기존 객체에서 sno를 꺼내어 사용하도록 변경

## Test
- 수정 테스트 정상 확인

## Other
없음